### PR TITLE
fix: i18n translations for @fernker-foo-library

### DIFF
--- a/libs/fooLibrary/src/locales/en_US.json
+++ b/libs/fooLibrary/src/locales/en_US.json
@@ -1,0 +1,3 @@
+{
+    "NEWER_KEY": "value23"
+}

--- a/libs/fooLibrary/src/locales/fr_FR.json
+++ b/libs/fooLibrary/src/locales/fr_FR.json
@@ -1,3 +1,3 @@
 {
-    "NEWER_KEY": ""
+    "NEWER_KEY": "bonjour"
 }


### PR DESCRIPTION
i18n: auto-generated from Cricut Desktop Translate script

