### PR TITLE
fix: i18n translations for @fernker-fake-library

### DIFF
--- a/libs/fakeLibrary/src/keysToLokalise.json
+++ b/libs/fakeLibrary/src/keysToLokalise.json
@@ -1,6 +1,1 @@
-{
-  "FOO_KEY": "FOO_VALUE",
-   "EXCITING": "ISNT IT",
-   "NEW_KEY": "value2"
-}
-  
+{"NEW_KEY":"value2"}

--- a/libs/fakeLibrary/src/locales/en_US.json
+++ b/libs/fakeLibrary/src/locales/en_US.json
@@ -1,0 +1,5 @@
+{
+    "FOO_KEY": "FOO_VALUE",
+    "EXCITING": "ISNT IT",
+    "NEW_KEY": "value"
+}

--- a/libs/fakeLibrary/src/locales/es_419.json
+++ b/libs/fakeLibrary/src/locales/es_419.json
@@ -1,0 +1,5 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": ""
+}

--- a/libs/fakeLibrary/src/locales/fr_FR.json
+++ b/libs/fakeLibrary/src/locales/fr_FR.json
@@ -1,0 +1,5 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": ""
+}


### PR DESCRIPTION
i18n: auto-generated from Cricut Desktop Translate script

ERRORED Keys for library @fernker-fake-library
 
ERROR: key NEW_KEY matches an existing key but has a different value