### PR TITLE
fix: i18n translations for @fernker-foo-library

### DIFF
--- a/libs/fakeLibrary/keysToLokalise.json
+++ b/libs/fakeLibrary/keysToLokalise.json
@@ -1,7 +1,3 @@
-
- {
-  "FOO_KEY": "FOO_VALUE",
-   "EXCITING": "ISNT IT",
-   "NEW_KEY": "value2",
-"TEST": "This is cool"
+{
+  "NEW_KEY": "value2"
 }

--- a/libs/fakeLibrary/src/locales/de_DE.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/de_DE.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/en_US.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/en_US.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "FOO_VALUE",
+    "EXCITING": "ISNT IT",
+    "NEW_KEY": "value",
+    "TEST": "This is cool"
+}

--- a/libs/fakeLibrary/src/locales/es_419.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/es_419.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/fr_FR.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/fr_FR.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/index.ts
+++ b/libs/fakeLibrary/src/locales/index.ts
@@ -1,0 +1,13 @@
+export { default as de_DE } from './de_DE.fakeLibrary2.i18n.json';
+export { default as en_US } from './en_US.fakeLibrary2.i18n.json';
+export { default as es_419 } from './es_419.fakeLibrary2.i18n.json';
+export { default as fr_FR } from './fr_FR.fakeLibrary2.i18n.json';
+export { default as it_IT } from './it_IT.fakeLibrary2.i18n.json';
+export { default as ja_JP } from './ja_JP.fakeLibrary2.i18n.json';
+export { default as ko_KR } from './ko_KR.fakeLibrary2.i18n.json';
+export { default as nl_NL } from './nl_NL.fakeLibrary2.i18n.json';
+export { default as pt_BR } from './pt_BR.fakeLibrary2.i18n.json';
+export { default as ru_RU } from './ru_RU.fakeLibrary2.i18n.json';
+export { default as tr_TR } from './tr_TR.fakeLibrary2.i18n.json';
+export { default as zh_CN } from './zh_CN.fakeLibrary2.i18n.json';
+export { default as zh_TW } from './zh_TW.fakeLibrary2.i18n.json';

--- a/libs/fakeLibrary/src/locales/it_IT.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/it_IT.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/ja_JP.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/ja_JP.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/ko_KR.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/ko_KR.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/nl_NL.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/nl_NL.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/pt_BR.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/pt_BR.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/ru_RU.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/ru_RU.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/tr_TR.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/tr_TR.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/zh_CN.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/zh_CN.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}

--- a/libs/fakeLibrary/src/locales/zh_TW.fakeLibrary2.i18n.json
+++ b/libs/fakeLibrary/src/locales/zh_TW.fakeLibrary2.i18n.json
@@ -1,0 +1,6 @@
+{
+    "FOO_KEY": "",
+    "EXCITING": "",
+    "NEW_KEY": "",
+    "TEST": ""
+}


### PR DESCRIPTION
i18n: auto-generated from Cricut Desktop Translate script

